### PR TITLE
Disable MFA

### DIFF
--- a/ui/geofm-demo-stack/lib/auth-stack.ts
+++ b/ui/geofm-demo-stack/lib/auth-stack.ts
@@ -38,7 +38,7 @@ export class AuthStack extends NestedStack {
         this.userPool = new cognito.UserPool(this, "UserPool", {
             userPoolName: `GeoFMDemoUsers-${props.envName}`,
             removalPolicy: RemovalPolicy.DESTROY,
-            mfa: cognito.Mfa.REQUIRED,
+            mfa: cognito.Mfa.OFF,
             
             signInAliases: { email: true, username: true },
             autoVerify: { email: true },


### PR DESCRIPTION
*Description of changes:*
This PR removes the MFA from the Cognito User Pool. On dev/test account, TOTP SMS sent by Cognito can be blocked with error "Blocked as spam by phone carrier". Because we don't want users of this sample to have to [configure Origination IDs](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-sms-settings.html#user-pool-sms-settings-first-time-origination), this PR just removes MFA requirement when authenticating.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
